### PR TITLE
Cleaned up spawn location, rotation

### DIFF
--- a/Assets/Prefabs/LevelPrefabs/Components/Spawn2 1.prefab
+++ b/Assets/Prefabs/LevelPrefabs/Components/Spawn2 1.prefab
@@ -63,26 +63,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &1052498361275588
-GameObject:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 4294884644105820}
-  - component: {fileID: 33768412047020046}
-  - component: {fileID: 23063796150880852}
-  - component: {fileID: 114390769853074576}
-  - component: {fileID: 114900308316758466}
-  - component: {fileID: 135672005484263934}
-  m_Layer: 0
-  m_Name: WeaponContainer5
-  m_TagString: WeaponContainer
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &1065066337940682
 GameObject:
   m_ObjectHideFlags: 0
@@ -94,6 +74,26 @@ GameObject:
   m_Layer: 0
   m_Name: SpireSpawnpoint (3)
   m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1091682679616800
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4000924425083774}
+  - component: {fileID: 33635965394974730}
+  - component: {fileID: 23342946818613036}
+  - component: {fileID: 114858407668899276}
+  - component: {fileID: 114145935808261154}
+  - component: {fileID: 135736983306710308}
+  m_Layer: 0
+  m_Name: WeaponContainer3
+  m_TagString: WeaponContainer
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -167,26 +167,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &1151268038178142
-GameObject:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 4711723308129178}
-  - component: {fileID: 33380883352530544}
-  - component: {fileID: 23709833066733444}
-  - component: {fileID: 114456536231146402}
-  - component: {fileID: 114837472856937688}
-  - component: {fileID: 135677057104636376}
-  m_Layer: 0
-  m_Name: WeaponContainer5
-  m_TagString: WeaponContainer
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &1217345267085404
 GameObject:
   m_ObjectHideFlags: 1
@@ -201,26 +181,6 @@ GameObject:
   m_Layer: 0
   m_Name: TutorialCanvas
   m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &1218070084508638
-GameObject:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 4471788793885594}
-  - component: {fileID: 33168475993151932}
-  - component: {fileID: 23622157741960054}
-  - component: {fileID: 114594735699068696}
-  - component: {fileID: 114376513618041216}
-  - component: {fileID: 135280658257342066}
-  m_Layer: 0
-  m_Name: WeaponContainer5
-  m_TagString: WeaponContainer
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -310,6 +270,46 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1308215364270066
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4026706443578016}
+  - component: {fileID: 33293323675018152}
+  - component: {fileID: 23698256228613416}
+  - component: {fileID: 114400314800577560}
+  - component: {fileID: 114509390608246580}
+  - component: {fileID: 135824001381713310}
+  m_Layer: 0
+  m_Name: WeaponContainer3
+  m_TagString: WeaponContainer
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1344215298916868
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4410953844145054}
+  - component: {fileID: 33853758010963784}
+  - component: {fileID: 23958321598684194}
+  - component: {fileID: 114415776717443432}
+  - component: {fileID: 114266292330703666}
+  - component: {fileID: 135179314384135264}
+  m_Layer: 0
+  m_Name: WeaponContainer3
+  m_TagString: WeaponContainer
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1 &1362181292737478
 GameObject:
   m_ObjectHideFlags: 1
@@ -341,6 +341,46 @@ GameObject:
   m_Layer: 0
   m_Name: TutorialCanvas
   m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1384293167868244
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4284041590170362}
+  - component: {fileID: 33749334419819356}
+  - component: {fileID: 23257299217232112}
+  - component: {fileID: 114301029763765630}
+  - component: {fileID: 114675738537564276}
+  - component: {fileID: 135125714669815212}
+  m_Layer: 0
+  m_Name: WeaponContainer3
+  m_TagString: WeaponContainer
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1399041319282564
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4466079997452078}
+  - component: {fileID: 33314868777089122}
+  - component: {fileID: 23519552926344486}
+  - component: {fileID: 114765993415775600}
+  - component: {fileID: 114099648146423620}
+  - component: {fileID: 135610471631687618}
+  m_Layer: 0
+  m_Name: WeaponContainer3
+  m_TagString: WeaponContainer
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -393,46 +433,6 @@ GameObject:
   m_Layer: 0
   m_Name: FriendlyTip
   m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &1469075490229076
-GameObject:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 4986388827605670}
-  - component: {fileID: 33783954841005572}
-  - component: {fileID: 23636115909075796}
-  - component: {fileID: 114850650901645620}
-  - component: {fileID: 114403860921601760}
-  - component: {fileID: 135967968429632184}
-  m_Layer: 0
-  m_Name: WeaponContainer5
-  m_TagString: WeaponContainer
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &1482734854490744
-GameObject:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 4444304113878988}
-  - component: {fileID: 33146842947599148}
-  - component: {fileID: 23760397890492962}
-  - component: {fileID: 114854503197197076}
-  - component: {fileID: 114192159002989928}
-  - component: {fileID: 135062398334035338}
-  m_Layer: 0
-  m_Name: WeaponContainer5
-  m_TagString: WeaponContainer
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -641,26 +641,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &1789290368462896
-GameObject:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 4251647661360510}
-  - component: {fileID: 33140408192521960}
-  - component: {fileID: 23097088488896186}
-  - component: {fileID: 114012752800755488}
-  - component: {fileID: 114236392933367802}
-  - component: {fileID: 135667391194755690}
-  m_Layer: 0
-  m_Name: WeaponContainer5
-  m_TagString: WeaponContainer
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &1799223847734434
 GameObject:
   m_ObjectHideFlags: 1
@@ -864,6 +844,39 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1993933841184542
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4857578134161562}
+  - component: {fileID: 33884045893522500}
+  - component: {fileID: 23086649194016796}
+  - component: {fileID: 114606153941292094}
+  - component: {fileID: 114441258371912974}
+  - component: {fileID: 135516040720184660}
+  m_Layer: 0
+  m_Name: WeaponContainer3
+  m_TagString: WeaponContainer
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4000924425083774
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1091682679616800}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 500, y: 500, z: 500}
+  m_Children: []
+  m_Father: {fileID: 4041800600696076}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4019433148593570
 Transform:
   m_ObjectHideFlags: 1
@@ -883,6 +896,19 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 30, z: 0}
+--- !u!4 &4026706443578016
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1308215364270066}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 500, y: 500, z: 500}
+  m_Children: []
+  m_Father: {fileID: 4085789186001734}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4041800600696076
 Transform:
   m_ObjectHideFlags: 1
@@ -890,12 +916,12 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1844359891857648}
   m_LocalRotation: {x: 0, y: 0.2588191, z: 0, w: 0.9659258}
-  m_LocalPosition: {x: 0.0276402, y: 0.4711, z: -0.04847421}
+  m_LocalPosition: {x: 0.0011, y: 0.4711, z: -0.0499}
   m_LocalScale: {x: 0.01, y: 0.01, z: 0.01}
   m_Children:
   - {fileID: 224276868603566302}
   - {fileID: 224493522934323486}
-  - {fileID: 4251647661360510}
+  - {fileID: 4000924425083774}
   m_Father: {fileID: 4019433148593570}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 30, z: 0}
@@ -906,39 +932,26 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1249808357478642}
   m_LocalRotation: {x: -0, y: -0.2588191, z: -0, w: 0.9659258}
-  m_LocalPosition: {x: -0.0135, y: 0.5, z: 0.031}
+  m_LocalPosition: {x: 0.0471, y: 0.4655, z: -0.0259}
   m_LocalScale: {x: 0.01, y: 0.01, z: 0.01}
   m_Children:
   - {fileID: 224265477083516080}
   - {fileID: 224576876607601194}
-  - {fileID: 4294884644105820}
+  - {fileID: 4026706443578016}
   m_Father: {fileID: 4019433148593570}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &4251647661360510
+--- !u!4 &4284041590170362
 Transform:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1789290368462896}
+  m_GameObject: {fileID: 1384293167868244}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 500, y: 500, z: 500}
   m_Children: []
-  m_Father: {fileID: 4041800600696076}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &4294884644105820
-Transform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1052498361275588}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 500, y: 500, z: 500}
-  m_Children: []
-  m_Father: {fileID: 4085789186001734}
+  m_Father: {fileID: 4926214817757306}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4300193884031686
@@ -948,34 +961,34 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1913164496741830}
   m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: -0.7071067}
-  m_LocalPosition: {x: 0.03026466, y: 0.4711, z: 0.047380056}
+  m_LocalPosition: {x: 0.0443, y: 0.4711, z: 0.0251}
   m_LocalScale: {x: 0.009999999, y: 0.01, z: 0.009999999}
   m_Children:
   - {fileID: 224999130774758092}
   - {fileID: 224762412548312308}
-  - {fileID: 4471788793885594}
+  - {fileID: 4466079997452078}
   m_Father: {fileID: 4019433148593570}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 300, z: 0}
---- !u!4 &4444304113878988
+--- !u!4 &4410953844145054
 Transform:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1482734854490744}
+  m_GameObject: {fileID: 1344215298916868}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 500, y: 500, z: 500}
   m_Children: []
-  m_Father: {fileID: 4926214817757306}
+  m_Father: {fileID: 4633650921173516}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &4471788793885594
+--- !u!4 &4466079997452078
 Transform:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1218070084508638}
+  m_GameObject: {fileID: 1399041319282564}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 500, y: 500, z: 500}
@@ -990,21 +1003,21 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1520279813442722}
   m_LocalRotation: {x: -0, y: 0.9659259, z: -0, w: -0.258819}
-  m_LocalPosition: {x: -0.0308, y: 0.4711, z: 0.0511}
+  m_LocalPosition: {x: -0.0007, y: 0.4711, z: 0.0502}
   m_LocalScale: {x: 0.010000001, y: 0.01, z: 0.010000001}
   m_Children:
   - {fileID: 224931183344791708}
   - {fileID: 224083460496968022}
-  - {fileID: 4986388827605670}
+  - {fileID: 4410953844145054}
   m_Father: {fileID: 4019433148593570}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 240, z: 0}
---- !u!4 &4711723308129178
+--- !u!4 &4857578134161562
 Transform:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1151268038178142}
+  m_GameObject: {fileID: 1993933841184542}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 500, y: 500, z: 500}
@@ -1019,12 +1032,12 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1832459480400770}
   m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 0.04, y: 0.4711, z: -0.0094}
+  m_LocalPosition: {x: -0.0421, y: 0.4711, z: -0.0226}
   m_LocalScale: {x: 0.010000001, y: 0.01, z: 0.010000001}
   m_Children:
   - {fileID: 224431523334346142}
   - {fileID: 224259035591672200}
-  - {fileID: 4444304113878988}
+  - {fileID: 4284041590170362}
   m_Father: {fileID: 4019433148593570}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
@@ -1035,68 +1048,21 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1065066337940682}
   m_LocalRotation: {x: -0, y: 0.9659258, z: -0, w: 0.2588191}
-  m_LocalPosition: {x: -0.05836825, y: 0.4711, z: 0.002096781}
+  m_LocalPosition: {x: -0.0416, y: 0.4711, z: 0.0234}
   m_LocalScale: {x: 0.01, y: 0.01, z: 0.01}
   m_Children:
   - {fileID: 224623099529034680}
   - {fileID: 224215694789538254}
-  - {fileID: 4711723308129178}
+  - {fileID: 4857578134161562}
   m_Father: {fileID: 4019433148593570}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
---- !u!4 &4986388827605670
-Transform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1469075490229076}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 500, y: 500, z: 500}
-  m_Children: []
-  m_Father: {fileID: 4633650921173516}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!23 &23063796150880852
+--- !u!23 &23086649194016796
 MeshRenderer:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1052498361275588}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_Materials:
-  - {fileID: 2100000, guid: e8fabadb5c73f5e478bff786c7fb1398, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!23 &23097088488896186
-MeshRenderer:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1789290368462896}
+  m_GameObject: {fileID: 1993933841184542}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -1159,12 +1125,12 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!23 &23622157741960054
+--- !u!23 &23257299217232112
 MeshRenderer:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1218070084508638}
+  m_GameObject: {fileID: 1384293167868244}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -1193,12 +1159,12 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!23 &23636115909075796
+--- !u!23 &23342946818613036
 MeshRenderer:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1469075490229076}
+  m_GameObject: {fileID: 1091682679616800}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -1227,12 +1193,12 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!23 &23709833066733444
+--- !u!23 &23519552926344486
 MeshRenderer:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1151268038178142}
+  m_GameObject: {fileID: 1399041319282564}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -1261,12 +1227,12 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!23 &23760397890492962
+--- !u!23 &23698256228613416
 MeshRenderer:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1482734854490744}
+  m_GameObject: {fileID: 1308215364270066}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -1295,27 +1261,47 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!33 &33140408192521960
+--- !u!23 &23958321598684194
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1344215298916868}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: e8fabadb5c73f5e478bff786c7fb1398, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &33293323675018152
 MeshFilter:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1789290368462896}
-  m_Mesh: {fileID: 4300000, guid: 6d65ff3600680834e86eab4da30fad51, type: 3}
---- !u!33 &33146842947599148
-MeshFilter:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1482734854490744}
-  m_Mesh: {fileID: 4300000, guid: 6d65ff3600680834e86eab4da30fad51, type: 3}
---- !u!33 &33168475993151932
-MeshFilter:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1218070084508638}
-  m_Mesh: {fileID: 4300000, guid: 6d65ff3600680834e86eab4da30fad51, type: 3}
+  m_GameObject: {fileID: 1308215364270066}
+  m_Mesh: {fileID: 4300000, guid: a465364e5423f2248b571d2643a5c1d1, type: 3}
 --- !u!33 &33308487158455418
 MeshFilter:
   m_ObjectHideFlags: 1
@@ -1323,27 +1309,41 @@ MeshFilter:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1836733141933248}
   m_Mesh: {fileID: 4300000, guid: 586b3cc452eee37408b8a60f6a2ea4bd, type: 3}
---- !u!33 &33380883352530544
+--- !u!33 &33314868777089122
 MeshFilter:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1151268038178142}
-  m_Mesh: {fileID: 4300000, guid: 6d65ff3600680834e86eab4da30fad51, type: 3}
---- !u!33 &33768412047020046
+  m_GameObject: {fileID: 1399041319282564}
+  m_Mesh: {fileID: 4300000, guid: a465364e5423f2248b571d2643a5c1d1, type: 3}
+--- !u!33 &33635965394974730
 MeshFilter:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1052498361275588}
-  m_Mesh: {fileID: 4300000, guid: 6d65ff3600680834e86eab4da30fad51, type: 3}
---- !u!33 &33783954841005572
+  m_GameObject: {fileID: 1091682679616800}
+  m_Mesh: {fileID: 4300000, guid: a465364e5423f2248b571d2643a5c1d1, type: 3}
+--- !u!33 &33749334419819356
 MeshFilter:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1469075490229076}
-  m_Mesh: {fileID: 4300000, guid: 6d65ff3600680834e86eab4da30fad51, type: 3}
+  m_GameObject: {fileID: 1384293167868244}
+  m_Mesh: {fileID: 4300000, guid: a465364e5423f2248b571d2643a5c1d1, type: 3}
+--- !u!33 &33853758010963784
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1344215298916868}
+  m_Mesh: {fileID: 4300000, guid: a465364e5423f2248b571d2643a5c1d1, type: 3}
+--- !u!33 &33884045893522500
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1993933841184542}
+  m_Mesh: {fileID: 4300000, guid: a465364e5423f2248b571d2643a5c1d1, type: 3}
 --- !u!64 &64642629759919484
 MeshCollider:
   m_ObjectHideFlags: 1
@@ -1391,32 +1391,6 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
---- !u!114 &114012752800755488
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1789290368462896}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  ownerId: 0
-  group: 0
-  OwnerShipWasTransfered: 0
-  prefixBackup: -1
-  synchronization: 3
-  onSerializeTransformOption: 3
-  onSerializeRigidBodyOption: 2
-  ownershipTransfer: 0
-  ObservedComponents:
-  - {fileID: 114236392933367802}
-  ObservedComponentsFoldoutOpen: 1
-  viewIdField: 0
-  instantiationId: -1
-  currentMasterID: -1
-  isRuntimeInstantiated: 0
 --- !u!114 &114032409558928570
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1449,13 +1423,17 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: '1. Find a weapon and click to shoot
+  m_Text: '1. Click to shoot weapon
 
-    2. Right click for special jump
+    2. Collect blue upgrades for weapon speed
 
-    3. Stay inside the shrinking zone
+    3. Collect yellow upgrades for weapon damage and size
 
-    4. Be the last man alive!'
+    4. Collect hearts to recover health
+
+    5. Stay inside the shrinking zone
+
+    6. Be the last man alive!'
 --- !u!114 &114034635333394574
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1488,13 +1466,17 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: '1. Find a weapon and click to shoot
+  m_Text: '1. Click to shoot weapon
 
-    2. Right click for special jump
+    2. Collect blue upgrades for weapon speed
 
-    3. Stay inside the shrinking zone
+    3. Collect yellow upgrades for weapon damage and size
 
-    4. Be the last man alive!'
+    4. Collect hearts to recover health
+
+    5. Stay inside the shrinking zone
+
+    6. Be the last man alive!'
 --- !u!114 &114061865068731116
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1592,6 +1574,20 @@ MonoBehaviour:
     5. Stay inside the shrinking zone
 
     6. Be the last man alive!'
+--- !u!114 &114099648146423620
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1399041319282564}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 49ab900e80016b143b04c4ef7b69756c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  timeToRespawn: 2
+  weapon: {fileID: 1136481300133536, guid: f65dff21e5b8c8f468d91ec4087024d8, type: 2}
+  m_type: 2
 --- !u!114 &114126302027471752
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1625,6 +1621,20 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: 
+--- !u!114 &114145935808261154
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1091682679616800}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 49ab900e80016b143b04c4ef7b69756c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  timeToRespawn: 2
+  weapon: {fileID: 1136481300133536, guid: f65dff21e5b8c8f468d91ec4087024d8, type: 2}
+  m_type: 2
 --- !u!114 &114147884283492492
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1690,13 +1700,17 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: '1. Find a weapon and click to shoot
+  m_Text: '1. Click to shoot weapon
 
-    2. Right click for special jump
+    2. Collect blue upgrades for weapon speed
 
-    3. Stay inside the shrinking zone
+    3. Collect yellow upgrades for weapon damage and size
 
-    4. Be the last man alive!'
+    4. Collect hearts to recover health
+
+    5. Stay inside the shrinking zone
+
+    6. Be the last man alive!'
 --- !u!114 &114169662199390074
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1729,13 +1743,17 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: '1. Find a weapon and click to shoot
+  m_Text: '1. Click to shoot weapon
 
-    2. Right click for special jump
+    2. Collect blue upgrades for weapon speed
 
-    3. Stay inside the shrinking zone
+    3. Collect yellow upgrades for weapon damage and size
 
-    4. Be the last man alive!'
+    4. Collect hearts to recover health
+
+    5. Stay inside the shrinking zone
+
+    6. Be the last man alive!'
 --- !u!114 &114175087431895466
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1806,20 +1824,6 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
---- !u!114 &114192159002989928
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1482734854490744}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 49ab900e80016b143b04c4ef7b69756c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  timeToRespawn: 2
-  weapon: {fileID: 1473387133061956, guid: 1832f071b6813c64481e1f7899e16a9e, type: 2}
-  m_type: 4
 --- !u!114 &114212635023297698
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1852,13 +1856,17 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: '1. Find a weapon and click to shoot
+  m_Text: '1. Click to shoot weapon
 
-    2. Right click for special jump
+    2. Collect blue upgrades for weapon speed
 
-    3. Stay inside the shrinking zone
+    3. Collect yellow upgrades for weapon damage and size
 
-    4. Be the last man alive!'
+    4. Collect hearts to recover health
+
+    5. Stay inside the shrinking zone
+
+    6. Be the last man alive!'
 --- !u!114 &114216541992328332
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1891,13 +1899,17 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: '1. Find a weapon and click to shoot
+  m_Text: '1. Click to shoot weapon
 
-    2. Right click for special jump
+    2. Collect blue upgrades for weapon speed
 
-    3. Stay inside the shrinking zone
+    3. Collect yellow upgrades for weapon damage and size
 
-    4. Be the last man alive!'
+    4. Collect hearts to recover health
+
+    5. Stay inside the shrinking zone
+
+    6. Be the last man alive!'
 --- !u!114 &114234731704986568
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1931,20 +1943,6 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: 
---- !u!114 &114236392933367802
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1789290368462896}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 49ab900e80016b143b04c4ef7b69756c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  timeToRespawn: 2
-  weapon: {fileID: 1473387133061956, guid: 1832f071b6813c64481e1f7899e16a9e, type: 2}
-  m_type: 4
 --- !u!114 &114248658763943532
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1977,13 +1975,17 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: '1. Find a weapon and click to shoot
+  m_Text: '1. Click to shoot weapon
 
-    2. Right click for special jump
+    2. Collect blue upgrades for weapon speed
 
-    3. Stay inside the shrinking zone
+    3. Collect yellow upgrades for weapon damage and size
 
-    4. Be the last man alive!'
+    4. Collect hearts to recover health
+
+    5. Stay inside the shrinking zone
+
+    6. Be the last man alive!'
 --- !u!114 &114253102046462084
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2005,6 +2007,20 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
+--- !u!114 &114266292330703666
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1344215298916868}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 49ab900e80016b143b04c4ef7b69756c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  timeToRespawn: 2
+  weapon: {fileID: 1136481300133536, guid: f65dff21e5b8c8f468d91ec4087024d8, type: 2}
+  m_type: 2
 --- !u!114 &114274508754733472
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2037,6 +2053,32 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+--- !u!114 &114301029763765630
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1384293167868244}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ownerId: 0
+  group: 0
+  OwnerShipWasTransfered: 0
+  prefixBackup: -1
+  synchronization: 3
+  onSerializeTransformOption: 3
+  onSerializeRigidBodyOption: 2
+  ownershipTransfer: 0
+  ObservedComponents:
+  - {fileID: 114675738537564276}
+  ObservedComponentsFoldoutOpen: 1
+  viewIdField: 0
+  instantiationId: -1
+  currentMasterID: -1
+  isRuntimeInstantiated: 0
 --- !u!114 &114310322600211740
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2111,13 +2153,17 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: '1. Find a weapon and click to shoot
+  m_Text: '1. Click to shoot weapon
 
-    2. Right click for special jump
+    2. Collect blue upgrades for weapon speed
 
-    3. Stay inside the shrinking zone
+    3. Collect yellow upgrades for weapon damage and size
 
-    4. Be the last man alive!'
+    4. Collect hearts to recover health
+
+    5. Stay inside the shrinking zone
+
+    6. Be the last man alive!'
 --- !u!114 &114344953719213072
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2166,33 +2212,23 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: '1. Find a weapon and click to shoot
+  m_Text: '1. Click to shoot weapon
 
-    2. Right click for special jump
+    2. Collect blue upgrades for weapon speed
 
-    3. Stay inside the shrinking zone
+    3. Collect yellow upgrades for weapon damage and size
 
-    4. Be the last man alive!'
---- !u!114 &114376513618041216
+    4. Collect hearts to recover health
+
+    5. Stay inside the shrinking zone
+
+    6. Be the last man alive!'
+--- !u!114 &114400314800577560
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1218070084508638}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 49ab900e80016b143b04c4ef7b69756c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  timeToRespawn: 2
-  weapon: {fileID: 1473387133061956, guid: 1832f071b6813c64481e1f7899e16a9e, type: 2}
-  m_type: 4
---- !u!114 &114390769853074576
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1052498361275588}
+  m_GameObject: {fileID: 1308215364270066}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
@@ -2207,26 +2243,38 @@ MonoBehaviour:
   onSerializeRigidBodyOption: 2
   ownershipTransfer: 0
   ObservedComponents:
-  - {fileID: 114900308316758466}
+  - {fileID: 114509390608246580}
   ObservedComponentsFoldoutOpen: 1
   viewIdField: 0
   instantiationId: -1
   currentMasterID: -1
   isRuntimeInstantiated: 0
---- !u!114 &114403860921601760
+--- !u!114 &114415776717443432
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1469075490229076}
+  m_GameObject: {fileID: 1344215298916868}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 49ab900e80016b143b04c4ef7b69756c, type: 3}
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  timeToRespawn: 2
-  weapon: {fileID: 1473387133061956, guid: 1832f071b6813c64481e1f7899e16a9e, type: 2}
-  m_type: 4
+  ownerId: 0
+  group: 0
+  OwnerShipWasTransfered: 0
+  prefixBackup: -1
+  synchronization: 3
+  onSerializeTransformOption: 3
+  onSerializeRigidBodyOption: 2
+  ownershipTransfer: 0
+  ObservedComponents:
+  - {fileID: 114266292330703666}
+  ObservedComponentsFoldoutOpen: 1
+  viewIdField: 0
+  instantiationId: -1
+  currentMasterID: -1
+  isRuntimeInstantiated: 0
 --- !u!114 &114441179219487142
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2243,32 +2291,20 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
---- !u!114 &114456536231146402
+--- !u!114 &114441258371912974
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1151268038178142}
+  m_GameObject: {fileID: 1993933841184542}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Script: {fileID: 11500000, guid: 49ab900e80016b143b04c4ef7b69756c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerId: 0
-  group: 0
-  OwnerShipWasTransfered: 0
-  prefixBackup: -1
-  synchronization: 3
-  onSerializeTransformOption: 3
-  onSerializeRigidBodyOption: 2
-  ownershipTransfer: 0
-  ObservedComponents:
-  - {fileID: 114837472856937688}
-  ObservedComponentsFoldoutOpen: 1
-  viewIdField: 0
-  instantiationId: -1
-  currentMasterID: -1
-  isRuntimeInstantiated: 0
+  timeToRespawn: 2
+  weapon: {fileID: 1136481300133536, guid: f65dff21e5b8c8f468d91ec4087024d8, type: 2}
+  m_type: 2
 --- !u!114 &114464487201463236
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2393,6 +2429,20 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+--- !u!114 &114509390608246580
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1308215364270066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 49ab900e80016b143b04c4ef7b69756c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  timeToRespawn: 2
+  weapon: {fileID: 1136481300133536, guid: f65dff21e5b8c8f468d91ec4087024d8, type: 2}
+  m_type: 2
 --- !u!114 &114532265519961814
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2474,13 +2524,17 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: '1. Find a weapon and click to shoot
+  m_Text: '1. Click to shoot weapon
 
-    2. Right click for special jump
+    2. Collect blue upgrades for weapon speed
 
-    3. Stay inside the shrinking zone
+    3. Collect yellow upgrades for weapon damage and size
 
-    4. Be the last man alive!'
+    4. Collect hearts to recover health
+
+    5. Stay inside the shrinking zone
+
+    6. Be the last man alive!'
 --- !u!114 &114580434265257926
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2497,32 +2551,6 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
---- !u!114 &114594735699068696
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1218070084508638}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  ownerId: 0
-  group: 0
-  OwnerShipWasTransfered: 0
-  prefixBackup: -1
-  synchronization: 3
-  onSerializeTransformOption: 3
-  onSerializeRigidBodyOption: 2
-  ownershipTransfer: 0
-  ObservedComponents:
-  - {fileID: 114376513618041216}
-  ObservedComponentsFoldoutOpen: 1
-  viewIdField: 0
-  instantiationId: -1
-  currentMasterID: -1
-  isRuntimeInstantiated: 0
 --- !u!114 &114596253861608106
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2556,6 +2584,32 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: 
+--- !u!114 &114606153941292094
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1993933841184542}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ownerId: 0
+  group: 0
+  OwnerShipWasTransfered: 0
+  prefixBackup: -1
+  synchronization: 3
+  onSerializeTransformOption: 3
+  onSerializeRigidBodyOption: 2
+  ownershipTransfer: 0
+  ObservedComponents:
+  - {fileID: 114441258371912974}
+  ObservedComponentsFoldoutOpen: 1
+  viewIdField: 0
+  instantiationId: -1
+  currentMasterID: -1
+  isRuntimeInstantiated: 0
 --- !u!114 &114626253893908688
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2643,6 +2697,20 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
+--- !u!114 &114675738537564276
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1384293167868244}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 49ab900e80016b143b04c4ef7b69756c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  timeToRespawn: 2
+  weapon: {fileID: 1136481300133536, guid: f65dff21e5b8c8f468d91ec4087024d8, type: 2}
+  m_type: 2
 --- !u!114 &114694175899884990
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2745,13 +2813,43 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: '1. Find a weapon and click to shoot
+  m_Text: '1. Click to shoot weapon
 
-    2. Right click for special jump
+    2. Collect blue upgrades for weapon speed
 
-    3. Stay inside the shrinking zone
+    3. Collect yellow upgrades for weapon damage and size
 
-    4. Be the last man alive!'
+    4. Collect hearts to recover health
+
+    5. Stay inside the shrinking zone
+
+    6. Be the last man alive!'
+--- !u!114 &114765993415775600
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1399041319282564}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ownerId: 0
+  group: 0
+  OwnerShipWasTransfered: 0
+  prefixBackup: -1
+  synchronization: 3
+  onSerializeTransformOption: 3
+  onSerializeRigidBodyOption: 2
+  ownershipTransfer: 0
+  ObservedComponents:
+  - {fileID: 114099648146423620}
+  ObservedComponentsFoldoutOpen: 1
+  viewIdField: 0
+  instantiationId: -1
+  currentMasterID: -1
+  isRuntimeInstantiated: 0
 --- !u!114 &114788510099063698
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2789,72 +2887,6 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
---- !u!114 &114837472856937688
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1151268038178142}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 49ab900e80016b143b04c4ef7b69756c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  timeToRespawn: 2
-  weapon: {fileID: 1473387133061956, guid: 1832f071b6813c64481e1f7899e16a9e, type: 2}
-  m_type: 4
---- !u!114 &114850650901645620
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1469075490229076}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  ownerId: 0
-  group: 0
-  OwnerShipWasTransfered: 0
-  prefixBackup: -1
-  synchronization: 3
-  onSerializeTransformOption: 3
-  onSerializeRigidBodyOption: 2
-  ownershipTransfer: 0
-  ObservedComponents:
-  - {fileID: 114403860921601760}
-  ObservedComponentsFoldoutOpen: 1
-  viewIdField: 0
-  instantiationId: -1
-  currentMasterID: -1
-  isRuntimeInstantiated: 0
---- !u!114 &114854503197197076
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1482734854490744}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  ownerId: 0
-  group: 0
-  OwnerShipWasTransfered: 0
-  prefixBackup: -1
-  synchronization: 3
-  onSerializeTransformOption: 3
-  onSerializeRigidBodyOption: 2
-  ownershipTransfer: 0
-  ObservedComponents:
-  - {fileID: 114192159002989928}
-  ObservedComponentsFoldoutOpen: 1
-  viewIdField: 0
-  instantiationId: -1
-  currentMasterID: -1
-  isRuntimeInstantiated: 0
 --- !u!114 &114857173498812636
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2876,6 +2908,32 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
+--- !u!114 &114858407668899276
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1091682679616800}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ownerId: 0
+  group: 0
+  OwnerShipWasTransfered: 0
+  prefixBackup: -1
+  synchronization: 3
+  onSerializeTransformOption: 3
+  onSerializeRigidBodyOption: 2
+  ownershipTransfer: 0
+  ObservedComponents:
+  - {fileID: 114145935808261154}
+  ObservedComponentsFoldoutOpen: 1
+  viewIdField: 0
+  instantiationId: -1
+  currentMasterID: -1
+  isRuntimeInstantiated: 0
 --- !u!114 &114871692279518082
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2892,20 +2950,6 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
---- !u!114 &114900308316758466
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1052498361275588}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 49ab900e80016b143b04c4ef7b69756c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  timeToRespawn: 2
-  weapon: {fileID: 1473387133061956, guid: 1832f071b6813c64481e1f7899e16a9e, type: 2}
-  m_type: 4
 --- !u!114 &114917901127260162
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2927,78 +2971,78 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
---- !u!135 &135062398334035338
+--- !u!135 &135125714669815212
 SphereCollider:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1482734854490744}
+  m_GameObject: {fileID: 1384293167868244}
   m_Material: {fileID: 0}
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Radius: 0.00045144075
-  m_Center: {x: 0.000000009662472, y: 0, z: 0}
---- !u!135 &135280658257342066
+  m_Radius: 0.00095437764
+  m_Center: {x: 0.000000010069925, y: 2.3283064e-10, z: 0}
+--- !u!135 &135179314384135264
 SphereCollider:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1218070084508638}
+  m_GameObject: {fileID: 1344215298916868}
   m_Material: {fileID: 0}
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Radius: 0.00045144075
-  m_Center: {x: 0.000000009662472, y: 0, z: 0}
---- !u!135 &135667391194755690
+  m_Radius: 0.00095437764
+  m_Center: {x: 0.000000010069925, y: 2.3283064e-10, z: 0}
+--- !u!135 &135516040720184660
 SphereCollider:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1789290368462896}
+  m_GameObject: {fileID: 1993933841184542}
   m_Material: {fileID: 0}
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Radius: 0.00045144075
-  m_Center: {x: 0.000000009662472, y: 0, z: 0}
---- !u!135 &135672005484263934
+  m_Radius: 0.00095437764
+  m_Center: {x: 0.000000010069925, y: 2.3283064e-10, z: 0}
+--- !u!135 &135610471631687618
 SphereCollider:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1052498361275588}
+  m_GameObject: {fileID: 1399041319282564}
   m_Material: {fileID: 0}
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Radius: 0.00045144075
-  m_Center: {x: 0.000000009662472, y: 0, z: 0}
---- !u!135 &135677057104636376
+  m_Radius: 0.00095437764
+  m_Center: {x: 0.000000010069925, y: 2.3283064e-10, z: 0}
+--- !u!135 &135736983306710308
 SphereCollider:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1151268038178142}
+  m_GameObject: {fileID: 1091682679616800}
   m_Material: {fileID: 0}
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Radius: 0.00045144075
-  m_Center: {x: 0.000000009662472, y: 0, z: 0}
---- !u!135 &135967968429632184
+  m_Radius: 0.00095437764
+  m_Center: {x: 0.000000010069925, y: 2.3283064e-10, z: 0}
+--- !u!135 &135824001381713310
 SphereCollider:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1469075490229076}
+  m_GameObject: {fileID: 1308215364270066}
   m_Material: {fileID: 0}
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Radius: 0.00045144075
-  m_Center: {x: 0.000000009662472, y: 0, z: 0}
+  m_Radius: 0.00095437764
+  m_Center: {x: 0.000000010069925, y: 2.3283064e-10, z: 0}
 --- !u!222 &222019901621138474
 CanvasRenderer:
   m_ObjectHideFlags: 1
@@ -3426,7 +3470,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1524759475891240}
   m_LocalRotation: {x: -0, y: 0.9659258, z: -0, w: -0.2588191}
-  m_LocalPosition: {x: 0, y: 0, z: 1.15}
+  m_LocalPosition: {x: 0, y: 0, z: 2.36}
   m_LocalScale: {x: 0.47999996, y: 0.48, z: 0.08}
   m_Children:
   - {fileID: 224091593078728776}
@@ -3436,7 +3480,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: -2.41, y: 0}
+  m_AnchoredPosition: {x: 0.46, y: 0}
   m_SizeDelta: {x: 10, y: 10}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224091593078728776
@@ -3472,7 +3516,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.0020523071, y: -2.5}
+  m_AnchoredPosition: {x: -0.0020523071, y: -1.7000103}
   m_SizeDelta: {x: 2000, y: 1000}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224178146325198036
@@ -3500,7 +3544,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1296874542318040}
   m_LocalRotation: {x: -0, y: 0.9659258, z: -0, w: -0.2588191}
-  m_LocalPosition: {x: 0, y: 0, z: 1.11}
+  m_LocalPosition: {x: 0, y: 0, z: 2.24}
   m_LocalScale: {x: 0.47999996, y: 0.48, z: 0.08}
   m_Children:
   - {fileID: 224661214518327324}
@@ -3510,7 +3554,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: -1.91, y: 0}
+  m_AnchoredPosition: {x: 0.53, y: 0}
   m_SizeDelta: {x: 10, y: 10}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224215843092476860
@@ -3538,7 +3582,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1376565693028374}
   m_LocalRotation: {x: -0, y: 0.9659258, z: -0, w: -0.2588191}
-  m_LocalPosition: {x: 0, y: 0, z: -6}
+  m_LocalPosition: {x: 0, y: 0, z: 2.37}
   m_LocalScale: {x: 0.47999996, y: 0.48, z: 0.08}
   m_Children:
   - {fileID: 224016321690858318}
@@ -3548,7 +3592,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 2.19, y: 0}
+  m_AnchoredPosition: {x: 0.79, y: 0}
   m_SizeDelta: {x: 10, y: 10}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224265477083516080
@@ -3558,7 +3602,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1031885733320218}
   m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0, z: -7.17}
+  m_LocalPosition: {x: 0, y: 0, z: 0.34}
   m_LocalScale: {x: 0.48000026, y: 0.48, z: 0.08000003}
   m_Children:
   - {fileID: 224707762012512822}
@@ -3568,7 +3612,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: -0.27999997, y: -2.1553612}
+  m_AnchoredPosition: {x: -2.68, y: 0.92}
   m_SizeDelta: {x: 10, y: 10}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224276868603566302
@@ -3578,7 +3622,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1232534895121862}
   m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0, z: -0.64}
+  m_LocalPosition: {x: 0, y: 0, z: 0.68}
   m_LocalScale: {x: 0.48000026, y: 0.48, z: 0.08000003}
   m_Children:
   - {fileID: 224901077749276034}
@@ -3588,7 +3632,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: -4.73, y: 0}
+  m_AnchoredPosition: {x: -2.57, y: 0}
   m_SizeDelta: {x: 10, y: 10}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224276996532233758
@@ -3606,7 +3650,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.0020523071, y: -2.5}
+  m_AnchoredPosition: {x: -0.0020523071, y: -1.7000103}
   m_SizeDelta: {x: 2000, y: 1000}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224280154687234244
@@ -3624,7 +3668,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.0020523071, y: -2.5}
+  m_AnchoredPosition: {x: -0.0020523071, y: -1.7000103}
   m_SizeDelta: {x: 2000, y: 1000}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224280161215731830
@@ -3642,7 +3686,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.0020523071, y: -2.5}
+  m_AnchoredPosition: {x: -0.0020523071, y: -1.7000103}
   m_SizeDelta: {x: 2000, y: 1000}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224431523334346142
@@ -3652,7 +3696,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1217345267085404}
   m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0, z: -7.3}
+  m_LocalPosition: {x: 0, y: 0, z: 0.53}
   m_LocalScale: {x: 0.48000026, y: 0.48, z: 0.08000003}
   m_Children:
   - {fileID: 224178146325198036}
@@ -3662,7 +3706,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: -0.88, y: 0}
+  m_AnchoredPosition: {x: -2.2, y: 0}
   m_SizeDelta: {x: 10, y: 10}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224441611748985206
@@ -3680,7 +3724,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.0020523071, y: -2.5}
+  m_AnchoredPosition: {x: -0.0020523071, y: -1.7000103}
   m_SizeDelta: {x: 2000, y: 1000}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224446271407858056
@@ -3698,7 +3742,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.0020523071, y: -2.5}
+  m_AnchoredPosition: {x: -0.0020523071, y: -1.7000103}
   m_SizeDelta: {x: 2000, y: 1000}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224493522934323486
@@ -3708,7 +3752,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1721058693252896}
   m_LocalRotation: {x: -0, y: 0.9659258, z: -0, w: -0.2588191}
-  m_LocalPosition: {x: 0, y: 0, z: 1.11}
+  m_LocalPosition: {x: 0, y: 0, z: 2.2}
   m_LocalScale: {x: 0.47999996, y: 0.48, z: 0.08}
   m_Children:
   - {fileID: 224626783162534726}
@@ -3718,7 +3762,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: -1.91, y: 0}
+  m_AnchoredPosition: {x: 0.74, y: 0}
   m_SizeDelta: {x: 10, y: 10}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224550500613853774
@@ -3736,7 +3780,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.0020523071, y: -2.5}
+  m_AnchoredPosition: {x: -0.0020523071, y: -1.7000103}
   m_SizeDelta: {x: 2000, y: 1000}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224552322766721568
@@ -3764,7 +3808,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1834754632656594}
   m_LocalRotation: {x: -0, y: 0.9659258, z: -0, w: -0.2588191}
-  m_LocalPosition: {x: 0, y: 0, z: -5.08}
+  m_LocalPosition: {x: 0, y: 0, z: 2.52}
   m_LocalScale: {x: 0.47999996, y: 0.48, z: 0.08}
   m_Children:
   - {fileID: 224552322766721568}
@@ -3774,7 +3818,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 2.37, y: -2.1553612}
+  m_AnchoredPosition: {x: 0.79, y: 0.920002}
   m_SizeDelta: {x: 10, y: 10}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224623099529034680
@@ -3784,7 +3828,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1107711001788048}
   m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0, z: -0.64}
+  m_LocalPosition: {x: 0, y: 0, z: 0.31}
   m_LocalScale: {x: 0.48000026, y: 0.48, z: 0.08000003}
   m_Children:
   - {fileID: 224983846894162728}
@@ -3794,7 +3838,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: -4.73, y: 0}
+  m_AnchoredPosition: {x: -2.25, y: 0}
   m_SizeDelta: {x: 10, y: 10}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224626783162534726
@@ -3876,7 +3920,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1427610226267768}
   m_LocalRotation: {x: -0, y: 0.9659258, z: -0, w: -0.2588191}
-  m_LocalPosition: {x: 0, y: 0, z: 1.11}
+  m_LocalPosition: {x: 0, y: 0, z: 2.45}
   m_LocalScale: {x: 0.47999996, y: 0.48, z: 0.08}
   m_Children:
   - {fileID: 224215843092476860}
@@ -3886,7 +3930,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: -1.91, y: 0}
+  m_AnchoredPosition: {x: 0.75, y: 0}
   m_SizeDelta: {x: 10, y: 10}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224794327259963890
@@ -3904,7 +3948,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.0020523071, y: -2.5}
+  m_AnchoredPosition: {x: -0.0020523071, y: -1.7000103}
   m_SizeDelta: {x: 2000, y: 1000}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224804204020348926
@@ -3922,7 +3966,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.0020523071, y: -2.5}
+  m_AnchoredPosition: {x: -0.0020523071, y: -1.7}
   m_SizeDelta: {x: 2000, y: 1000}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224864689509406060
@@ -3940,7 +3984,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.0020523071, y: -2.5}
+  m_AnchoredPosition: {x: -0.0020523071, y: -1.7000103}
   m_SizeDelta: {x: 2000, y: 1000}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224889770648724846
@@ -3958,7 +4002,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.0020523071, y: -2.5}
+  m_AnchoredPosition: {x: -0.0020523071, y: -1.7000103}
   m_SizeDelta: {x: 2000, y: 1000}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224901077749276034
@@ -3986,7 +4030,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1849520481573622}
   m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0, z: -0.36}
+  m_LocalPosition: {x: 0, y: 0, z: 0.6}
   m_LocalScale: {x: 0.48000026, y: 0.48, z: 0.08000003}
   m_Children:
   - {fileID: 224015953282767758}
@@ -3996,7 +4040,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: -5.1, y: 0}
+  m_AnchoredPosition: {x: -2.48, y: 0}
   m_SizeDelta: {x: 10, y: 10}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224983846894162728
@@ -4032,7 +4076,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.0020523071, y: -2.5}
+  m_AnchoredPosition: {x: -0.0020523071, y: -1.7000103}
   m_SizeDelta: {x: 2000, y: 1000}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224999130774758092
@@ -4042,7 +4086,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1827975770553764}
   m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0, z: -0.64}
+  m_LocalPosition: {x: 0, y: 0, z: 0.83}
   m_LocalScale: {x: 0.48000026, y: 0.48, z: 0.08000003}
   m_Children:
   - {fileID: 224704865211516736}
@@ -4052,6 +4096,6 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: -4.73, y: 0}
+  m_AnchoredPosition: {x: -2.42, y: 0}
   m_SizeDelta: {x: 10, y: 10}
   m_Pivot: {x: 0.5, y: 0.5}

--- a/Assets/Scripts/PhotonNetworkManager.cs
+++ b/Assets/Scripts/PhotonNetworkManager.cs
@@ -116,7 +116,7 @@ public class PhotonNetworkManager : Photon.PunBehaviour
                 
                 int id = go.GetComponent<PhotonView>().ownerId;
 				go.transform.Translate(spawnPoint[id % spawnPoint.Length].position.x, spawnPoint[id % spawnPoint.Length].position.y, spawnPoint[id % spawnPoint.Length].position.z);
-                
+				go.transform.Rotate (new Vector3 (0, 1, 0), (id % spawnPoint.Length) * 60 - 30);
 
 
 


### PR DESCRIPTION
Tweaked spawn location so that you spawn in the center of your spawn platform.

Also added code so that all players spawn facing the inside wall where the instructions are.

The updated spawn is a prefab named "Spawn 2 1". You can find it inside Prefabs/Level Prefabs/Components.

To add it to the level, drag the prefab into the scene, delete/hide the old spawn, then update the network manager with the new spawn locations. The spawns must be added according to the numbering for the rotation to work as intended.